### PR TITLE
Fix for error on logout

### DIFF
--- a/back-end/src/auth/auth.controller.ts
+++ b/back-end/src/auth/auth.controller.ts
@@ -22,23 +22,23 @@ export class AuthController {
   user(@Request() req) {
     return req.user
   }
-  
+
   @UseGuards(LoginGuard)
   @Get('/callback')
   loginCallback(@Res() res: Response) {
     res.redirect('/');
   }
-  
+
   @Get('/logout')
   async logout(@Request() req, @Res() res: Response) {
     const id_token = req.user ? req.user.id_token: undefined;
     req.logout();
     req.session.destroy(async (error: any) => {
-      const TrustIssuer = await Issuer.discover(`${process.env.OAUTH2_CLIENT_PROVIDER_GOOGLE_ISSUER}/.well-known/openid-configuration`);
+      const TrustIssuer = await Issuer.discover(`${process.env.OAUTH2_CLIENT_PROVIDER_OIDC_ISSUER}/.well-known/openid-configuration`);
       const end_session_endpoint = TrustIssuer.metadata.end_session_endpoint;
       if (end_session_endpoint) {
-        res.redirect(end_session_endpoint + 
-          '?post_logout_redirect_uri=' + process.env.OAUTH2_CLIENT_REGISTRATION_LOGIN_POST_LOGOUT_REDIRECT_URI + 
+        res.redirect(end_session_endpoint +
+          '?post_logout_redirect_uri=' + process.env.OAUTH2_CLIENT_REGISTRATION_LOGIN_POST_LOGOUT_REDIRECT_URI +
           (id_token ? '&id_token_hint=' + id_token : ''));
       } else {
         res.redirect('/')


### PR DESCRIPTION
Clicking on logout gives error TypeError: Only valid absolute URLs can be requested

On investigation this turns out to be a mis-named variable (an alternative workaround was described in issue #5 )

Fixed variable name to use the variable stored in env file as described in blog

OAUTH2_CLIENT_PROVIDER_GOOGLE_ISSUER is changed to OAUTH2_CLIENT_PROVIDER_OIDC_ISSUER